### PR TITLE
Add a Github Pages Pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: CI
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v2
+
+      - name: Rename into index.html
+        run: mv ./web_demo/demo.html ./web_demo/index.html
+
+      - name: Deploy
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./web_demo


### PR DESCRIPTION
# Purpose
This PR adds an automated pipeline for publishing the content of `web_demo` folder on https://pgermon.github.io/teach_DRL_demo

# Steps needed before PR merge:
In the project settings, Github pages should be enabled and the source should point on `gh-pages` branch:
![image](https://user-images.githubusercontent.com/1043441/112225392-029a0f80-8c2d-11eb-91a5-5bb63a4aa656.png)

# Does it work?
I forked the repository and tested the pipeline manually. The result looks like this: https://nikita.melkozerov.dev/teach_DRL_demo/
